### PR TITLE
fix fade with 3 digits colors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## TBA
 - Fix #42: Division by zero (when trying to lighten white color)
+- Fix #43: Invalid faded color calculated from 3 digits base color
 
 ## 0.3.0 (14 february 2024)
 **NOTE** Files in themes/FlexTheme/css now need to be writable by the PHP process (see https://docs.humhub.org/docs/admin/installation/#file-permissions)

--- a/helpers/ColorHelper.php
+++ b/helpers/ColorHelper.php
@@ -86,6 +86,9 @@ class ColorHelper
 
     public static function fade(string $color, int $amount): string
     {
+        // make sure we have 6 letters code not 3
+        $color = '#' . self::getSixDigitsColor($color);
+        
         // $amount is expected to be between 0 and 100
         $opacity = ($amount / 100) * 255;
         $opacity = max(min($opacity, 255), 0); // keep between 0 and 255
@@ -97,13 +100,18 @@ class ColorHelper
 
     protected static function getColorComponents(string $color): array
     {
+        $hexstr = self::getSixDigitsColor($color);
+        return str_split($hexstr, 2);
+    }
+
+    protected static function getSixDigitsColor(string $color): string
+    {
         // Remove leading '#'
         $hexstr = ltrim($color, '#');
         // if color has just 3 digits
         if (strlen($hexstr) == 3) {
             $hexstr = $hexstr[0] . $hexstr[0] . $hexstr[1] . $hexstr[1] . $hexstr[2] . $hexstr[2];
         }
-
-        return str_split($hexstr, 2);
+        return $hexstr;
     }
 }


### PR DESCRIPTION
When e.g. background4 was a 3 digit color (e.g. `#000`), the calculated color background4--fade--50 was invalid (e.g. `#0007f`).