### PR TITLE
Fix configuration instructions

### DIFF
--- a/views/config/dark-colors.php
+++ b/views/config/dark-colors.php
@@ -16,7 +16,7 @@ $link = '<a href=' . $darkModeUrl . '>' . $darkModeName . '</a>';
 ?>
 <div class="panel-body">
     <div class="alert alert-info">
-        <p><?= Yii::t('FlexThemeModule.admin', 'Please use the module {darkmode} and select "HumHub (dark)".', [
+        <p><?= Yii::t('FlexThemeModule.admin', 'Please use the module {darkmode} and select "FlexTheme (dark)".', [
             'darkmode' => $link,
         ]) ?>
         </p>


### PR DESCRIPTION
After installing the darkmode module and following the original instructions my custom colors were not displayed correctly when enabling dark mode.

Switching the dark mode theme to 'FlexTheme (dark)' fixed the issue for me.